### PR TITLE
IOS2-1102-CDMessage-setReadStatus-forUserID-line-154

### DIFF
--- a/ChatSDKCoreData/Classes/Entities/CDThread.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread.m
@@ -177,17 +177,15 @@
 
 -(void) markRead {
     
-    if !BChatSDK.currentUserID {
-        return
-    }
-    
     BOOL didMarkRead = NO;
     
     for(id<PMessage> message in self.messages) {
         if (!message.isRead && !message.senderIsMe) {
 //            [message setRead:[NSNumber numberWithInt:bMessageReadStatusRead]];
 //            [message setRead: [NSNumber numberWithInt:bMessageReadStatusRead]];
-            [message setReadStatus:bMessageReadStatusRead forUserID:BChatSDK.currentUserID];
+            if BChatSDK.currentUserID != nil {
+                [message setReadStatus:bMessageReadStatusRead forUserID:BChatSDK.currentUserID];
+            }
 //            [message setReadStatus:bMessageReadStatusDelivered forUserID:BChatSDK.currentUserID];
 
             // TODO: Should we have this here? Maybe this gets called too soon

--- a/ChatSDKCoreData/Classes/Entities/CDThread.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread.m
@@ -177,6 +177,10 @@
 
 -(void) markRead {
     
+    if !BChatSDK.currentUserID {
+        return
+    }
+    
     BOOL didMarkRead = NO;
     
     for(id<PMessage> message in self.messages) {


### PR DESCRIPTION
IOS2-1102 - Fix exception: -[__NSDictionaryM setObject:forKeyedSubscript:]: key cannot be nil