### PR TITLE
IOS2-1102-CDMessage-setReadStatus-forUserID-line-154

### DIFF
--- a/ChatSDKCoreData/Classes/Entities/CDThread.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread.m
@@ -185,6 +185,8 @@
 //            [message setRead: [NSNumber numberWithInt:bMessageReadStatusRead]];
             if (BChatSDK.currentUserID != nil) {
                 [message setReadStatus:bMessageReadStatusRead forUserID:BChatSDK.currentUserID];
+            } else {
+                [message setRead:@(bMessageReadStatusRead)];
             }
 //            [message setReadStatus:bMessageReadStatusDelivered forUserID:BChatSDK.currentUserID];
 


### PR DESCRIPTION
IOS2-1102 - Add `[message setRead:@(bMessageReadStatusRead)];` if `BChatSDK.currentUserID` is `nil`